### PR TITLE
Handle additional success case on device close

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -309,7 +309,8 @@ impl std::error::Error for Error {}
 impl Error {
     pub fn from_result(result: ctl_result_t) -> Result<(), Self> {
         match result {
-            ctl_result_t::CTL_RESULT_SUCCESS => Ok(()),
+            ctl_result_t::CTL_RESULT_SUCCESS
+            | ctl_result_t::CTL_RESULT_SUCCESS_STILL_OPEN_BY_ANOTHER_CALLER => Ok(()),
             x => Err(Self(x)),
         }
     }


### PR DESCRIPTION
This essentially closes #3, if we assume that it still being open by another caller is fine in general (i.e. we will lose this context).

As described in that issue, we currently report a success (`CTL_RESULT_SUCCESS_STILL_OPEN_BY_ANOTHER_CALLER`) as if an error. Given the library states this as an actual success when returned and no indication of any failure, it seems safe to assume that we can dismiss the "still open by another caller" part of it). Either way, there seems no good reason to handle this as error at the moment.

We directly check for `CTL_RESULT_SUCCESS` in a few other cases. I contemplated changing those as well, but this specific return value doesn't seem like it should be returned by those instances at all, as those check for individual features. We could still make it consistent so that we just convert to an `Error` type on results and check `is_ok()` instead, rather than such manual checks.