### PR TITLE
Fix value type for getting frame limit control

### DIFF
--- a/src/device_adapter.rs
+++ b/src/device_adapter.rs
@@ -167,7 +167,7 @@ impl DeviceAdapter {
                 ApplicationName: current_app.as_mut_ptr() as *mut _,
                 ApplicationNameLength: current_app.as_bytes().len() as i8,
                 bSet: false,
-                ValueType: ctl_property_value_type_t::CTL_PROPERTY_VALUE_TYPE_ENUM,
+                ValueType: ctl_property_value_type_t::CTL_PROPERTY_VALUE_TYPE_INT32,
                 Value: unsafe { std::mem::zeroed() },
                 CustomValueSize: 0,
                 pCustomValue: std::ptr::null_mut(),

--- a/src/device_adapter.rs
+++ b/src/device_adapter.rs
@@ -152,6 +152,9 @@ impl DeviceAdapter {
 
     /// Attempt to query the frame rate limit driver setting.
     /// Falls back to a higher scope if the setting could not be found in the current one.
+    ///  
+    /// Returned value is the current or most-recent configured frame limit,
+    /// seemingly regardless of whether the feature is enabled.
     pub fn feature_frame_limit(&self, scope: DriverSettingScope<'_>) -> Result<i32> {
         let mut result = ctl_result_t::CTL_RESULT_ERROR_UNKNOWN;
         let mut scope = Some(scope);


### PR DESCRIPTION
If set to `ENUM`, this would always return zero. Possibly a copy-paste error, but it's understandable as the control lib seems to still return `CTL_RESULT_SUCCESS` here. That's quite confusing behaviour, since changing this does seem to affect what the driver returns. I'd expect it to return `CTL_RESULT_ERROR_INVALID_ARGUMENT` here instead. The value is a union, so it shouldn't matter whether we tried to get its `IntType` or `EnumType`, even if may have been incorrect it wouldn't be zero, so it's likely the call does check if the requested type is correct.

